### PR TITLE
NO-JIRA: Adds prevent accidental merge workflow and removes deprecated tags within CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          tags: true
+          fetch-tags: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -78,7 +78,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
+          fetch-tags: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/prevent-accidental-merge.yml
+++ b/.github/workflows/prevent-accidental-merge.yml
@@ -1,0 +1,38 @@
+name: Prevent Main Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current PR information
+        id: get-pr-info
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Get the current PR data
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            // Set outputs with current source and target branches
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('base_ref', pr.data.base.ref);
+
+      - name: Check if source branch is valid for target
+        run: |
+          echo "Source branch: ${{ steps.get-pr-info.outputs.head_ref }}"
+          echo "Target branch: ${{ steps.get-pr-info.outputs.base_ref }}"
+
+          # Use the fetched branch information
+          if [[ "${{ steps.get-pr-info.outputs.base_ref }}" == "main" && "${{ steps.get-pr-info.outputs.head_ref }}" != release-* ]]; then
+            echo "Error: Only branches starting with 'release-' can be merged into main."
+            exit 1
+          fi

--- a/.github/workflows/prevent-accidental-merge.yml
+++ b/.github/workflows/prevent-accidental-merge.yml
@@ -32,7 +32,7 @@ jobs:
           echo "Target branch: ${{ steps.get-pr-info.outputs.base_ref }}"
 
           # Use the fetched branch information
-          if [[ "${{ steps.get-pr-info.outputs.base_ref }}" == "main" && "${{ steps.get-pr-info.outputs.head_ref }}" != release-* ]]; then
-            echo "Error: Only branches starting with 'release-' can be merged into main."
+          if [[ "${{ steps.get-pr-info.outputs.base_ref }}" == "master" && "${{ steps.get-pr-info.outputs.head_ref }}" != release-* ]]; then
+            echo "Error: Only branches starting with 'release-' can be merged into master."
             exit 1
           fi

--- a/.github/workflows/prevent-accidental-merge.yml
+++ b/.github/workflows/prevent-accidental-merge.yml
@@ -1,9 +1,9 @@
-name: Prevent Main Merge
+name: Prevent Master Merge
 
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   check-branch-name:


### PR DESCRIPTION
# Description

I wanted to prevent accidental merges to master and enforce my release workflow. This adds a github workflow that will prevent the accidental merge to master.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested via github

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


